### PR TITLE
- Made all register insert and register save commands un-set their ac…

### DIFF
--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -311,7 +311,7 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   for (const char of asciiPrintableChars) {
     keybindings.push({
       key: char,
-      when: "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+      when: "emacs-mcx.inRegisterSaveMode && editorTextFocus",
       command: "emacs-mcx.RegisterSaveCommand",
       args: [char],
     });
@@ -320,7 +320,7 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   for (const char of asciiPrintableChars) {
     keybindings.push({
       key: char,
-      when: "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+      when: "emacs-mcx.inRegisterInsertMode && editorTextFocus",
       command: "emacs-mcx.RegisterInsertCommand",
       args: [char],
     });

--- a/keybindings.json
+++ b/keybindings.json
@@ -750,7 +750,7 @@
     {
       "key": "k", // ctrl+x r k
       "command": "emacs-mcx.killRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "s", // ctrl+x r s
@@ -768,12 +768,12 @@
     {
       "key": "y", // ctrl+x r y
       "command": "emacs-mcx.yankRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "d", // ctrl+x r d
       "command": "emacs-mcx.deleteRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "meta+w", // ctrl+x r M-w
@@ -783,22 +783,22 @@
     {
       "key": "o", // ctrl+x r o
       "command": "emacs-mcx.openRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "c", // ctrl+x r c
       "command": "emacs-mcx.clearRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "t", // ctrl+x r t
       "command": "emacs-mcx.stringRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus)"
     },
     {
       "key": "p", // ctrl+x r p
       "command": "emacs-mcx.replaceKillRingToRectangle",
-      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+      "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "$special": "rectMarkModeTypes"

--- a/package.json
+++ b/package.json
@@ -3966,7 +3966,7 @@
       {
         "key": "k",
         "command": "emacs-mcx.killRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "s",
@@ -3980,7 +3980,7 @@
       },
       {
         "key": " ",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           " "
@@ -3988,7 +3988,7 @@
       },
       {
         "key": "!",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "!"
@@ -3996,7 +3996,7 @@
       },
       {
         "key": "\"",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "\""
@@ -4004,7 +4004,7 @@
       },
       {
         "key": "#",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "#"
@@ -4012,7 +4012,7 @@
       },
       {
         "key": "$",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "$"
@@ -4020,7 +4020,7 @@
       },
       {
         "key": "%",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "%"
@@ -4028,7 +4028,7 @@
       },
       {
         "key": "&",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "&"
@@ -4036,7 +4036,7 @@
       },
       {
         "key": "'",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "'"
@@ -4044,7 +4044,7 @@
       },
       {
         "key": "(",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "("
@@ -4052,7 +4052,7 @@
       },
       {
         "key": ")",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           ")"
@@ -4060,7 +4060,7 @@
       },
       {
         "key": "*",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "*"
@@ -4068,7 +4068,7 @@
       },
       {
         "key": "+",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "+"
@@ -4076,7 +4076,7 @@
       },
       {
         "key": ",",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           ","
@@ -4084,7 +4084,7 @@
       },
       {
         "key": "-",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "-"
@@ -4092,7 +4092,7 @@
       },
       {
         "key": ".",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "."
@@ -4100,7 +4100,7 @@
       },
       {
         "key": "/",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "/"
@@ -4108,7 +4108,7 @@
       },
       {
         "key": "0",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "0"
@@ -4116,7 +4116,7 @@
       },
       {
         "key": "1",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "1"
@@ -4124,7 +4124,7 @@
       },
       {
         "key": "2",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "2"
@@ -4132,7 +4132,7 @@
       },
       {
         "key": "3",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "3"
@@ -4140,7 +4140,7 @@
       },
       {
         "key": "4",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "4"
@@ -4148,7 +4148,7 @@
       },
       {
         "key": "5",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "5"
@@ -4156,7 +4156,7 @@
       },
       {
         "key": "6",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "6"
@@ -4164,7 +4164,7 @@
       },
       {
         "key": "7",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "7"
@@ -4172,7 +4172,7 @@
       },
       {
         "key": "8",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "8"
@@ -4180,7 +4180,7 @@
       },
       {
         "key": "9",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "9"
@@ -4188,7 +4188,7 @@
       },
       {
         "key": ":",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           ":"
@@ -4196,7 +4196,7 @@
       },
       {
         "key": ";",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           ";"
@@ -4204,7 +4204,7 @@
       },
       {
         "key": "<",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "<"
@@ -4212,7 +4212,7 @@
       },
       {
         "key": "=",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "="
@@ -4220,7 +4220,7 @@
       },
       {
         "key": ">",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           ">"
@@ -4228,7 +4228,7 @@
       },
       {
         "key": "?",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "?"
@@ -4236,7 +4236,7 @@
       },
       {
         "key": "@",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "@"
@@ -4244,7 +4244,7 @@
       },
       {
         "key": "A",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "A"
@@ -4252,7 +4252,7 @@
       },
       {
         "key": "B",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "B"
@@ -4260,7 +4260,7 @@
       },
       {
         "key": "C",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "C"
@@ -4268,7 +4268,7 @@
       },
       {
         "key": "D",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "D"
@@ -4276,7 +4276,7 @@
       },
       {
         "key": "E",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "E"
@@ -4284,7 +4284,7 @@
       },
       {
         "key": "F",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "F"
@@ -4292,7 +4292,7 @@
       },
       {
         "key": "G",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "G"
@@ -4300,7 +4300,7 @@
       },
       {
         "key": "H",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "H"
@@ -4308,7 +4308,7 @@
       },
       {
         "key": "I",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "I"
@@ -4316,7 +4316,7 @@
       },
       {
         "key": "J",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "J"
@@ -4324,7 +4324,7 @@
       },
       {
         "key": "K",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "K"
@@ -4332,7 +4332,7 @@
       },
       {
         "key": "L",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "L"
@@ -4340,7 +4340,7 @@
       },
       {
         "key": "M",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "M"
@@ -4348,7 +4348,7 @@
       },
       {
         "key": "N",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "N"
@@ -4356,7 +4356,7 @@
       },
       {
         "key": "O",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "O"
@@ -4364,7 +4364,7 @@
       },
       {
         "key": "P",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "P"
@@ -4372,7 +4372,7 @@
       },
       {
         "key": "Q",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "Q"
@@ -4380,7 +4380,7 @@
       },
       {
         "key": "R",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "R"
@@ -4388,7 +4388,7 @@
       },
       {
         "key": "S",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "S"
@@ -4396,7 +4396,7 @@
       },
       {
         "key": "T",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "T"
@@ -4404,7 +4404,7 @@
       },
       {
         "key": "U",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "U"
@@ -4412,7 +4412,7 @@
       },
       {
         "key": "V",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "V"
@@ -4420,7 +4420,7 @@
       },
       {
         "key": "W",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "W"
@@ -4428,7 +4428,7 @@
       },
       {
         "key": "X",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "X"
@@ -4436,7 +4436,7 @@
       },
       {
         "key": "Y",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "Y"
@@ -4444,7 +4444,7 @@
       },
       {
         "key": "Z",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "Z"
@@ -4452,7 +4452,7 @@
       },
       {
         "key": "[",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "["
@@ -4460,7 +4460,7 @@
       },
       {
         "key": "\\",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "\\"
@@ -4468,7 +4468,7 @@
       },
       {
         "key": "]",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "]"
@@ -4476,7 +4476,7 @@
       },
       {
         "key": "^",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "^"
@@ -4484,7 +4484,7 @@
       },
       {
         "key": "_",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "_"
@@ -4492,7 +4492,7 @@
       },
       {
         "key": "`",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "`"
@@ -4500,7 +4500,7 @@
       },
       {
         "key": "a",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "a"
@@ -4508,7 +4508,7 @@
       },
       {
         "key": "b",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "b"
@@ -4516,7 +4516,7 @@
       },
       {
         "key": "c",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "c"
@@ -4524,7 +4524,7 @@
       },
       {
         "key": "d",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "d"
@@ -4532,7 +4532,7 @@
       },
       {
         "key": "e",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "e"
@@ -4540,7 +4540,7 @@
       },
       {
         "key": "f",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "f"
@@ -4548,7 +4548,7 @@
       },
       {
         "key": "g",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "g"
@@ -4556,7 +4556,7 @@
       },
       {
         "key": "h",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "h"
@@ -4564,7 +4564,7 @@
       },
       {
         "key": "i",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "i"
@@ -4572,7 +4572,7 @@
       },
       {
         "key": "j",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "j"
@@ -4580,7 +4580,7 @@
       },
       {
         "key": "k",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "k"
@@ -4588,7 +4588,7 @@
       },
       {
         "key": "l",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "l"
@@ -4596,7 +4596,7 @@
       },
       {
         "key": "m",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "m"
@@ -4604,7 +4604,7 @@
       },
       {
         "key": "n",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "n"
@@ -4612,7 +4612,7 @@
       },
       {
         "key": "o",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "o"
@@ -4620,7 +4620,7 @@
       },
       {
         "key": "p",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "p"
@@ -4628,7 +4628,7 @@
       },
       {
         "key": "q",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "q"
@@ -4636,7 +4636,7 @@
       },
       {
         "key": "r",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "r"
@@ -4644,7 +4644,7 @@
       },
       {
         "key": "s",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "s"
@@ -4652,7 +4652,7 @@
       },
       {
         "key": "t",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "t"
@@ -4660,7 +4660,7 @@
       },
       {
         "key": "u",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "u"
@@ -4668,7 +4668,7 @@
       },
       {
         "key": "v",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "v"
@@ -4676,7 +4676,7 @@
       },
       {
         "key": "w",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "w"
@@ -4684,7 +4684,7 @@
       },
       {
         "key": "x",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "x"
@@ -4692,7 +4692,7 @@
       },
       {
         "key": "y",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "y"
@@ -4700,7 +4700,7 @@
       },
       {
         "key": "z",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "z"
@@ -4708,7 +4708,7 @@
       },
       {
         "key": "{",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "{"
@@ -4716,7 +4716,7 @@
       },
       {
         "key": "|",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "|"
@@ -4724,7 +4724,7 @@
       },
       {
         "key": "}",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "}"
@@ -4732,7 +4732,7 @@
       },
       {
         "key": "~",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterSaveMode",
+        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
         "command": "emacs-mcx.RegisterSaveCommand",
         "args": [
           "~"
@@ -4740,7 +4740,7 @@
       },
       {
         "key": " ",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           " "
@@ -4748,7 +4748,7 @@
       },
       {
         "key": "!",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "!"
@@ -4756,7 +4756,7 @@
       },
       {
         "key": "\"",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "\""
@@ -4764,7 +4764,7 @@
       },
       {
         "key": "#",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "#"
@@ -4772,7 +4772,7 @@
       },
       {
         "key": "$",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "$"
@@ -4780,7 +4780,7 @@
       },
       {
         "key": "%",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "%"
@@ -4788,7 +4788,7 @@
       },
       {
         "key": "&",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "&"
@@ -4796,7 +4796,7 @@
       },
       {
         "key": "'",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "'"
@@ -4804,7 +4804,7 @@
       },
       {
         "key": "(",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "("
@@ -4812,7 +4812,7 @@
       },
       {
         "key": ")",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           ")"
@@ -4820,7 +4820,7 @@
       },
       {
         "key": "*",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "*"
@@ -4828,7 +4828,7 @@
       },
       {
         "key": "+",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "+"
@@ -4836,7 +4836,7 @@
       },
       {
         "key": ",",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           ","
@@ -4844,7 +4844,7 @@
       },
       {
         "key": "-",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "-"
@@ -4852,7 +4852,7 @@
       },
       {
         "key": ".",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "."
@@ -4860,7 +4860,7 @@
       },
       {
         "key": "/",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "/"
@@ -4868,7 +4868,7 @@
       },
       {
         "key": "0",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "0"
@@ -4876,7 +4876,7 @@
       },
       {
         "key": "1",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "1"
@@ -4884,7 +4884,7 @@
       },
       {
         "key": "2",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "2"
@@ -4892,7 +4892,7 @@
       },
       {
         "key": "3",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "3"
@@ -4900,7 +4900,7 @@
       },
       {
         "key": "4",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "4"
@@ -4908,7 +4908,7 @@
       },
       {
         "key": "5",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "5"
@@ -4916,7 +4916,7 @@
       },
       {
         "key": "6",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "6"
@@ -4924,7 +4924,7 @@
       },
       {
         "key": "7",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "7"
@@ -4932,7 +4932,7 @@
       },
       {
         "key": "8",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "8"
@@ -4940,7 +4940,7 @@
       },
       {
         "key": "9",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "9"
@@ -4948,7 +4948,7 @@
       },
       {
         "key": ":",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           ":"
@@ -4956,7 +4956,7 @@
       },
       {
         "key": ";",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           ";"
@@ -4964,7 +4964,7 @@
       },
       {
         "key": "<",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "<"
@@ -4972,7 +4972,7 @@
       },
       {
         "key": "=",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "="
@@ -4980,7 +4980,7 @@
       },
       {
         "key": ">",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           ">"
@@ -4988,7 +4988,7 @@
       },
       {
         "key": "?",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "?"
@@ -4996,7 +4996,7 @@
       },
       {
         "key": "@",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "@"
@@ -5004,7 +5004,7 @@
       },
       {
         "key": "A",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "A"
@@ -5012,7 +5012,7 @@
       },
       {
         "key": "B",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "B"
@@ -5020,7 +5020,7 @@
       },
       {
         "key": "C",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "C"
@@ -5028,7 +5028,7 @@
       },
       {
         "key": "D",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "D"
@@ -5036,7 +5036,7 @@
       },
       {
         "key": "E",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "E"
@@ -5044,7 +5044,7 @@
       },
       {
         "key": "F",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "F"
@@ -5052,7 +5052,7 @@
       },
       {
         "key": "G",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "G"
@@ -5060,7 +5060,7 @@
       },
       {
         "key": "H",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "H"
@@ -5068,7 +5068,7 @@
       },
       {
         "key": "I",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "I"
@@ -5076,7 +5076,7 @@
       },
       {
         "key": "J",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "J"
@@ -5084,7 +5084,7 @@
       },
       {
         "key": "K",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "K"
@@ -5092,7 +5092,7 @@
       },
       {
         "key": "L",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "L"
@@ -5100,7 +5100,7 @@
       },
       {
         "key": "M",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "M"
@@ -5108,7 +5108,7 @@
       },
       {
         "key": "N",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "N"
@@ -5116,7 +5116,7 @@
       },
       {
         "key": "O",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "O"
@@ -5124,7 +5124,7 @@
       },
       {
         "key": "P",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "P"
@@ -5132,7 +5132,7 @@
       },
       {
         "key": "Q",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "Q"
@@ -5140,7 +5140,7 @@
       },
       {
         "key": "R",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "R"
@@ -5148,7 +5148,7 @@
       },
       {
         "key": "S",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "S"
@@ -5156,7 +5156,7 @@
       },
       {
         "key": "T",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "T"
@@ -5164,7 +5164,7 @@
       },
       {
         "key": "U",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "U"
@@ -5172,7 +5172,7 @@
       },
       {
         "key": "V",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "V"
@@ -5180,7 +5180,7 @@
       },
       {
         "key": "W",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "W"
@@ -5188,7 +5188,7 @@
       },
       {
         "key": "X",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "X"
@@ -5196,7 +5196,7 @@
       },
       {
         "key": "Y",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "Y"
@@ -5204,7 +5204,7 @@
       },
       {
         "key": "Z",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "Z"
@@ -5212,7 +5212,7 @@
       },
       {
         "key": "[",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "["
@@ -5220,7 +5220,7 @@
       },
       {
         "key": "\\",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "\\"
@@ -5228,7 +5228,7 @@
       },
       {
         "key": "]",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "]"
@@ -5236,7 +5236,7 @@
       },
       {
         "key": "^",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "^"
@@ -5244,7 +5244,7 @@
       },
       {
         "key": "_",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "_"
@@ -5252,7 +5252,7 @@
       },
       {
         "key": "`",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "`"
@@ -5260,7 +5260,7 @@
       },
       {
         "key": "a",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "a"
@@ -5268,7 +5268,7 @@
       },
       {
         "key": "b",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "b"
@@ -5276,7 +5276,7 @@
       },
       {
         "key": "c",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "c"
@@ -5284,7 +5284,7 @@
       },
       {
         "key": "d",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "d"
@@ -5292,7 +5292,7 @@
       },
       {
         "key": "e",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "e"
@@ -5300,7 +5300,7 @@
       },
       {
         "key": "f",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "f"
@@ -5308,7 +5308,7 @@
       },
       {
         "key": "g",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "g"
@@ -5316,7 +5316,7 @@
       },
       {
         "key": "h",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "h"
@@ -5324,7 +5324,7 @@
       },
       {
         "key": "i",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "i"
@@ -5332,7 +5332,7 @@
       },
       {
         "key": "j",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "j"
@@ -5340,7 +5340,7 @@
       },
       {
         "key": "k",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "k"
@@ -5348,7 +5348,7 @@
       },
       {
         "key": "l",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "l"
@@ -5356,7 +5356,7 @@
       },
       {
         "key": "m",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "m"
@@ -5364,7 +5364,7 @@
       },
       {
         "key": "n",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "n"
@@ -5372,7 +5372,7 @@
       },
       {
         "key": "o",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "o"
@@ -5380,7 +5380,7 @@
       },
       {
         "key": "p",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "p"
@@ -5388,7 +5388,7 @@
       },
       {
         "key": "q",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "q"
@@ -5396,7 +5396,7 @@
       },
       {
         "key": "r",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "r"
@@ -5404,7 +5404,7 @@
       },
       {
         "key": "s",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "s"
@@ -5412,7 +5412,7 @@
       },
       {
         "key": "t",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "t"
@@ -5420,7 +5420,7 @@
       },
       {
         "key": "u",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "u"
@@ -5428,7 +5428,7 @@
       },
       {
         "key": "v",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "v"
@@ -5436,7 +5436,7 @@
       },
       {
         "key": "w",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "w"
@@ -5444,7 +5444,7 @@
       },
       {
         "key": "x",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "x"
@@ -5452,7 +5452,7 @@
       },
       {
         "key": "y",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "y"
@@ -5460,7 +5460,7 @@
       },
       {
         "key": "z",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "z"
@@ -5468,7 +5468,7 @@
       },
       {
         "key": "{",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "{"
@@ -5476,7 +5476,7 @@
       },
       {
         "key": "|",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "|"
@@ -5484,7 +5484,7 @@
       },
       {
         "key": "}",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "}"
@@ -5492,7 +5492,7 @@
       },
       {
         "key": "~",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && emacs-mcx.inRegisterInsertMode",
+        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.RegisterInsertCommand",
         "args": [
           "~"
@@ -5501,12 +5501,12 @@
       {
         "key": "y",
         "command": "emacs-mcx.yankRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "d",
         "command": "emacs-mcx.deleteRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "alt+w",
@@ -5532,22 +5532,22 @@
       {
         "key": "o",
         "command": "emacs-mcx.openRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "c",
         "command": "emacs-mcx.clearRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "t",
         "command": "emacs-mcx.stringRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus)"
       },
       {
         "key": "p",
         "command": "emacs-mcx.replaceKillRingToRectangle",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !(emacs-mcx.inRegisterSaveMode || emacs-mcx.inRegisterInsertMode)"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": " ",

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -9,6 +9,7 @@ export class StartRegisterSaveCommand extends EmacsCommand implements IEmacsComm
 
   private startRegisterSaveCommand(): void {
     this.acceptingRegisterSaveCommand = true;
+    vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
     vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterSaveMode", true);
   }
 
@@ -36,6 +37,7 @@ export class StartRegisterInsertCommand extends EmacsCommand implements IEmacsCo
 
   public startRegisterInsertCommand(): void {
     this.acceptingRegisterInsertCommand = true;
+    vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
     vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterInsertMode", true);
   }
 


### PR DESCRIPTION
Dramatically cleaner implementation based on whitphx suggestion. The .json's are much cleaner. Basically startRegisterInsertCommand() and startRegisterSaveCommand() un-set the emacs-mcx.acceptingRectCommand context 